### PR TITLE
Create facebook callback

### DIFF
--- a/facebook callback
+++ b/facebook callback
@@ -1,0 +1,45 @@
+<?php
+$fb = new Facebook\Facebook([
+  'app_id' => '{app-id}',
+  'app_secret' => '{app-secret}',
+  'default_graph_version' => 'v2.2',
+]);
+ 
+$helper = $fb->getRedirectLoginHelper();
+ 
+try {
+  $accessToken = $helper->getAccessToken();
+} catch(Facebook\Exceptions\FacebookResponseException $e) {
+  // When Graph returns an error
+  echo 'Graph returned an error: ' . $e->getMessage();
+  exit;
+} catch(Facebook\Exceptions\FacebookSDKException $e) {
+  // When validation fails or other local issues
+  echo 'Facebook SDK returned an error: ' . $e->getMessage();
+  exit;
+}
+ 
+if (! isset($accessToken)) {
+  if ($helper->getError()) {
+    header('HTTP/1.0 401 Unauthorized');
+    echo "Error: " . $helper->getError() . "\n";
+    echo "Error Code: " . $helper->getErrorCode() . "\n";
+    echo "Error Reason: " . $helper->getErrorReason() . "\n";
+    echo "Error Description: " . $helper->getErrorDescription() . "\n";
+  } else {
+    header('HTTP/1.0 400 Bad Request');
+    echo 'Bad request';
+  }
+  exit;
+}
+ 
+// Logged in
+// The OAuth 2.0 client handler helps us manage access tokens
+$oAuth2Client = $fb->getOAuth2Client();
+ 
+// Get the access token metadata from /debug_token
+$tokenMetadata = $oAuth2Client->debugToken($accessToken);
+ 
+// Get user’s Facebook ID
+$userId = $tokenMetadata->getField('user_id');
+?>


### PR DESCRIPTION
1. The customer signup page for the password column has some bug where users could not signup even though they have follow the statement. The statement can be fix by using the empty($password)' instead of using password ==
2. I would like to add some code referring to the facebook page using the Facebook php SDK